### PR TITLE
Fix release workflow for windows build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,9 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Build with CMake
+        env:
+          CC: clang-cl
+          CXX: clang-cl
         run: |
           cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
           cmake --build build
@@ -160,8 +163,8 @@ jobs:
           sudo chmod +x llvm.sh
           sudo ./llvm.sh ${LLVM_VERSION}
           sudo apt-get install -y -q libc++-${LLVM_VERSION}-dev libc++abi-${LLVM_VERSION}-dev
-          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_VERSION} 100
-          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_VERSION} 100
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_VERSION} 200
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_VERSION} 200
 
       - name: Set up CMake and Ninja
         uses: lukka/get-cmake@latest


### PR DESCRIPTION
Updated the windows CMake build environment to use clang-cl as the compiler and adjusted the priority for update-alternatives on linux build